### PR TITLE
feat: support template reuse

### DIFF
--- a/docs/content/1.get-started.md
+++ b/docs/content/1.get-started.md
@@ -63,7 +63,7 @@ Then, create a `template.rntmd` file in your project root directory.
 <!-- END commits SECTION -->
 
 <!-- END breaking SECTION -->
-<!-- BEGIN feat SECTION -->
+<!-- BEGIN feat, fix, docs, chore, refactor, test SECTION -->
 
 ### {{ title }}
 
@@ -72,57 +72,7 @@ Then, create a `template.rntmd` file in your project root directory.
 - {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
 <!-- END commits SECTION -->
 
-<!-- END feat SECTION -->
-<!-- BEGIN fix SECTION -->
-
-### {{ title }}
-
-<!-- BEGIN commits SECTION -->
-
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
-<!-- END commits SECTION -->
-
-<!-- END fix SECTION -->
-<!-- BEGIN docs SECTION -->
-
-### {{ title }}
-
-<!-- BEGIN commits SECTION -->
-
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
-<!-- END commits SECTION -->
-
-<!-- END docs SECTION -->
-<!-- BEGIN chore SECTION -->
-
-### {{ title }}
-
-<!-- BEGIN commits SECTION -->
-
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
-<!-- END commits SECTION -->
-
-<!-- END chore SECTION -->
-<!-- BEGIN refactor SECTION -->
-
-### {{ title }}
-
-<!-- BEGIN commits SECTION -->
-
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
-<!-- END commits SECTION -->
-
-<!-- END refactor SECTION -->
-<!-- BEGIN test SECTION -->
-
-### {{ title }}
-
-<!-- BEGIN commits SECTION -->
-
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
-<!-- END commits SECTION -->
-
-<!-- END test SECTION -->
+<!-- END feat, fix, docs, chore, refactor, test SECTION -->
 <!-- Generate by Release Note -->
 ```
 ::

--- a/docs/content/2.guide/3.template/2.section-syntax.md
+++ b/docs/content/2.guide/3.template/2.section-syntax.md
@@ -1,6 +1,9 @@
 # Section Syntax
 
+You can use section tag to define a section in your template file.
+
 Begin Syntax: `<!-- BEGIN section SECTION -->`
+
 End Syntax: `<!-- END section SECTION -->`
 
 Examples:
@@ -13,7 +16,21 @@ This is a test section.
 ```
 ::
 
-You can use section tag to define a section in your template file.
+If you have the same template content in multiple sections, you can define it with the following syntax:
+
+::code-group
+```markdown [Template]
+<!-- BEGIN feat, refactor, test SECTION -->
+The content in this section will be generated in feat, refactor and test sections.
+<!-- END feat, refactor, test SECTION -->
+```
+::
+
+It is very useful when you have a lot of sections with the same content.
+
+::alert{type="warning"}
+The begin tags and end tags must be identical.
+::
 
 Available sections:
 
@@ -22,5 +39,5 @@ Available sections:
     - `commits`
 
 ::alert{type="warning"}
-`default` section is not a real section, it is the default context of the template file.
+`default` section is not a real section, it is the default context of the template file. In generate process, Relno will insert `default` section end tag at the end of the template file. As a result, you should never use `default` as a section name.
 ::

--- a/packages/relno/__tests__/generator/generator.test.ts
+++ b/packages/relno/__tests__/generator/generator.test.ts
@@ -314,4 +314,67 @@ describe("Generator test", () => {
     expect(await generator.generate()).toBe(result);
     expect(await generator.generate()).toBe(result);
   });
+  test("reuse template", async () => {
+    const generator = new Generator(commits, {
+      prTypes,
+      template: `## 📝 Changelog
+
+[compare changes]({{ compareUrl }})
+
+<!-- BEGIN breaking SECTION -->
+### {{ title }}
+
+<!-- BEGIN commits SECTION -->
+- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ toSentence(message) }} (#{{ prNumber }})
+<!-- END commits SECTION -->
+
+<!-- END breaking SECTION -->
+<!-- BEGIN feat, fix, docs, chore, refactor, test SECTION -->
+### {{ title }}
+
+<!-- BEGIN commits SECTION -->
+- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
+<!-- END commits SECTION -->
+
+<!-- END feat, fix, docs, chore, refactor, test SECTION -->
+<!-- Generate by Release Note -->`,
+      metadata,
+    });
+    expect(await generator.generate()).toBe(`## 📝 Changelog
+
+[compare changes](https://test.com/compare/1...2)
+
+### ⚠️ Breaking Changes
+
+- Breaking change feature (#987)
+
+### 🚀 Enhancements
+
+- frontend: List UI improvement (#212)
+- Search engine friendly CoursesSearch (#199)
+- ⚠️ Breaking change feature (#987)
+
+### 🩹 Fixes
+
+- frontend: Invalid route in ReviewFrame (#210)
+- frontend: Page number isn't reset when changing filter (#203)
+- Feedback page params validation (#201)
+- Page value is inconsistent (#197)
+- Course feedback test failed sometime (#195)
+- Show wrong page when user view feedback and back (#192)
+- Wrong dev proxy setting (#191)
+
+### 🏡 Chore
+
+- Remove unnecessary files (#193)
+- deps: Update pnpm to v7.17.0 (#190)
+
+### 💅 Refactors
+
+- frontend: Direct call api endpoint instead of calling wrapper (#207)
+- frontend: Paginator state management (#205)
+
+<!-- Generate by Release Note -->
+`);
+  });
 });

--- a/packages/relno/__tests__/generator/parser/template-parser.test.ts
+++ b/packages/relno/__tests__/generator/parser/template-parser.test.ts
@@ -10,6 +10,7 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [],
     });
   });
@@ -20,10 +21,27 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [
         {
           type: TemplateNodeType.Text,
           value: "test\n",
+        },
+      ],
+    });
+  });
+  test("with html comment", () => {
+    const parser = new TemplateParser({
+      template: "<!-- test -->",
+    });
+    expect(parser.parse()).toEqual({
+      type: TemplateNodeType.Section,
+      name: "default",
+      tags: ["default"],
+      children: [
+        {
+          type: TemplateNodeType.Text,
+          value: "<!-- test -->\n",
         },
       ],
     });
@@ -35,11 +53,13 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [
         {
           type: TemplateNodeType.Section,
           name: "test",
           parent: "default",
+          tags: ["test"],
           children: [
             {
               type: TemplateNodeType.Text,
@@ -58,6 +78,7 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [
         {
           type: TemplateNodeType.Text,
@@ -67,6 +88,7 @@ describe("Template parser test", () => {
           type: TemplateNodeType.Section,
           name: "test",
           parent: "default",
+          tags: ["test"],
           children: [
             {
               type: TemplateNodeType.Text,
@@ -85,6 +107,7 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [
         {
           type: TemplateNodeType.Text,
@@ -94,6 +117,7 @@ describe("Template parser test", () => {
           type: TemplateNodeType.Section,
           name: "test1",
           parent: "default",
+          tags: ["test1"],
           children: [
             {
               type: TemplateNodeType.Text,
@@ -109,6 +133,7 @@ describe("Template parser test", () => {
           type: TemplateNodeType.Section,
           name: "test2",
           parent: "default",
+          tags: ["test2"],
           children: [
             {
               type: TemplateNodeType.Text,
@@ -131,6 +156,7 @@ describe("Template parser test", () => {
     expect(parser.parse()).toEqual({
       type: TemplateNodeType.Section,
       name: "default",
+      tags: ["default"],
       children: [
         {
           type: TemplateNodeType.Text,
@@ -140,6 +166,7 @@ describe("Template parser test", () => {
           type: TemplateNodeType.Section,
           name: "test1",
           parent: "default",
+          tags: ["test1"],
           children: [
             {
               type: TemplateNodeType.Text,
@@ -149,6 +176,7 @@ describe("Template parser test", () => {
               type: TemplateNodeType.Section,
               name: "test2",
               parent: "test1",
+              tags: ["test2"],
               children: [
                 {
                   type: TemplateNodeType.Text,
@@ -165,6 +193,120 @@ describe("Template parser test", () => {
         {
           type: TemplateNodeType.Text,
           value: "b\n",
+        },
+      ],
+    });
+  });
+  test("reuse pr type section", () => {
+    const parser = new TemplateParser({
+      template:
+        "<!-- BEGIN test1, test2 SECTION -->\ntest\n<!-- END test1, test2 SECTION -->",
+    });
+    expect(parser.parse()).toEqual({
+      type: TemplateNodeType.Section,
+      name: "default",
+      tags: ["default"],
+      children: [
+        {
+          type: TemplateNodeType.Section,
+          name: "test1",
+          parent: "default",
+          tags: ["test1", "test2"],
+          children: [
+            {
+              type: TemplateNodeType.Text,
+              value: "test\n",
+            },
+          ],
+        },
+        {
+          type: TemplateNodeType.Section,
+          name: "test2",
+          parent: "default",
+          tags: ["test1", "test2"],
+          children: [
+            {
+              type: TemplateNodeType.Text,
+              value: "test\n",
+            },
+          ],
+        },
+      ],
+    });
+  });
+  test("reuse pr type section and contain neated section", () => {
+    const parser = new TemplateParser({
+      template:
+        "<!-- BEGIN test1, test2 SECTION -->\n<!-- BEGIN test3, test4 SECTION -->\ntest\n<!-- END test3, test4 SECTION -->\n<!-- END test1, test2 SECTION -->",
+    });
+    expect(parser.parse()).toEqual({
+      type: TemplateNodeType.Section,
+      name: "default",
+      tags: ["default"],
+      children: [
+        {
+          type: TemplateNodeType.Section,
+          name: "test1",
+          parent: "default",
+          tags: ["test1", "test2"],
+          children: [
+            {
+              type: TemplateNodeType.Section,
+              name: "test3",
+              parent: "test1",
+              tags: ["test3", "test4"],
+              children: [
+                {
+                  type: TemplateNodeType.Text,
+                  value: "test\n",
+                },
+              ],
+            },
+            {
+              type: TemplateNodeType.Section,
+              name: "test4",
+              parent: "test1",
+              tags: ["test3", "test4"],
+              children: [
+                {
+                  type: TemplateNodeType.Text,
+                  value: "test\n",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: TemplateNodeType.Section,
+          name: "test2",
+          parent: "default",
+          tags: ["test1", "test2"],
+          children: [
+            {
+              type: TemplateNodeType.Section,
+              name: "test3",
+              parent: "test2",
+              tags: ["test3", "test4"],
+              children: [
+                {
+                  type: TemplateNodeType.Text,
+                  value: "test\n",
+                },
+              ],
+            },
+            {
+              type: TemplateNodeType.Section,
+              name: "test4",
+              parent: "test2",
+              tags: ["test3", "test4"],
+              children: [
+                {
+                  type: TemplateNodeType.Text,
+                  value: "test\n",
+                },
+              ],
+            },
+          ],
         },
       ],
     });

--- a/packages/relno/src/generator/generator.ts
+++ b/packages/relno/src/generator/generator.ts
@@ -181,6 +181,7 @@ async function parseDefaultSection(
   const result: SectionNode = {
     type: TemplateNodeType.Section,
     name: sectionNode.name,
+    tags: sectionNode.tags,
     children: [],
   };
   for (const child of sectionNode.children) {
@@ -201,17 +202,13 @@ async function parsePRTypeSection(
     (e) => e.prType.identifier === sectionNode.name,
   );
   if (!data) throw new Error(`Can't find section ${sectionNode.name}`);
-  if (data.commits.length === 0)
-    return {
-      type: TemplateNodeType.Section,
-      name: sectionNode.name,
-      children: [],
-    };
   const result: SectionNode = {
     type: TemplateNodeType.Section,
     name: sectionNode.name,
+    tags: sectionNode.tags,
     children: [],
   };
+  if (data.commits.length === 0) return result;
   for (const child of sectionNode.children) {
     result.children.push(
       await parseNode(generator, child, {
@@ -231,17 +228,13 @@ async function parseCommitsSection(
     (e) => e.prType.identifier === sectionNode.parent,
   );
   if (!data) throw new Error(`Can't find section ${sectionNode.parent}`);
-  if (data.commits.length === 0)
-    return {
-      type: TemplateNodeType.Section,
-      name: sectionNode.name,
-      children: [],
-    };
   const result: SectionNode = {
     type: TemplateNodeType.Section,
     name: sectionNode.name,
+    tags: sectionNode.tags,
     children: [],
   };
+  if (data.commits.length === 0) return result;
   for (const commit of data.commits) {
     for (const child of sectionNode.children) {
       const regex = /([^()\n!]+)(?:\((.*)\))?(!)?: (.+) \(#([1-9][0-9]*)\)/;

--- a/packages/relno/src/generator/parser/template-ast.ts
+++ b/packages/relno/src/generator/parser/template-ast.ts
@@ -15,6 +15,7 @@ export interface TextNode extends TemplateNode {
 export interface SectionNode extends TemplateNode {
   type: TemplateNodeType.Section;
   name: string;
+  tags: string[];
   parent?: string;
   children: TemplateNode[];
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#14 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
The template parser can now parser sections like `<!-- BEGIN feat, test SECTION -->`. In this example, it will generate two section nodes, allowing the generator to generate the same output.
Closes #14.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
